### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/content/api-endpoints/accessing.md
+++ b/content/api-endpoints/accessing.md
@@ -5,7 +5,7 @@ weight = "3"
 
 ## API versions
 
-The Cloud Foundry API is constantly evolving. The [v2 API](https://apidocs.cloudfoundry.org) is now deprecated and has been replaced by the [v3 API](https://v3-apidocs.cloudfoundry.org). You should have general awareness that these API versions exist.
+The Cloud Foundry API is constantly evolving. The [v2 API](https://v2-apidocs.cloudfoundry.org) is now deprecated and has been replaced by the [v3 API](https://v3-apidocs.cloudfoundry.org). You should have general awareness that these API versions exist.
 
 ## Accessing the API
 

--- a/content/exam/anatomy.md
+++ b/content/exam/anatomy.md
@@ -101,7 +101,7 @@ Programming tasks and specific programming languages are not in scope. The exam 
 In addition to the testing interface detailed in the next section, you may have **one** additional browser tab opened during the exam. In that tab, you will be allowed to access:
 
 - docs.cloudfoundry.org
-- apidocs.cloudfoundry.org
+- v2-apidocs.cloudfoundry.org
 - v3-apidocs.cloudfoundry.org
 - plugins.cloudfoundry.org
 


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)